### PR TITLE
Fixed bug where an invalid proposal is created

### DIFF
--- a/contracts/VouchMarket.sol
+++ b/contracts/VouchMarket.sol
@@ -133,6 +133,7 @@ contract VouchMarket {
         Proposal storage thisProposal = proposalMap[idProposal];
         uint256 amount = msg.value;
         require(amount > 0, "money?");
+        require(msg.sender != voucher, "Voucher must not be self address");
         uint64 timeLimit = uint64(block.timestamp) + addedTime;
         thisProposal.user = msg.sender;
         thisProposal.amount = amount;


### PR DESCRIPTION
This bug actually affected users in several times. If a proposal is created with self address as designated voucher, it cannot be taken by anyone or be modified